### PR TITLE
ci(pr): add checks for dependent issues

### DIFF
--- a/.github/workflows/dependent-issues.yaml
+++ b/.github/workflows/dependent-issues.yaml
@@ -1,0 +1,34 @@
+name: Dependent Issues
+
+on:
+  issues:
+    types:
+      - opened
+      - edited
+      - reopened
+  pull_request:
+    types:
+      - opened
+      - edited
+      - reopened
+      - synchronize # Add status check for PRs.
+
+  # Schedule a daily check.
+  # Used in referencing cross-repository issues or pull requests
+  schedule:
+    - cron: '0 0 * * *'
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      issues: read
+      statuses: write
+    steps:
+      - uses: z0al/dependent-issues@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          check_issues: off # Do not check issues
+          keywords: depends on, blocked by, based on


### PR DESCRIPTION
Related to #8 

## What's new

This added an action check for dependent issues/prs (via specified keywords `depends on, blocked by, based on`) and add a pending status to the current PR  + a comment for visibility.