### PR TITLE
ci(build): image builds for push events

### DIFF
--- a/.github/workflows/build-ci.yaml
+++ b/.github/workflows/build-ci.yaml
@@ -1,0 +1,126 @@
+name: Container image build
+
+concurrency:
+  group: ci-${{ github.run_id }}
+  cancel-in-progress: true
+
+on:
+  push:
+    branches:
+      - "develop"
+      - "master"
+      - "main"
+  workflow_dispatch:
+
+env:
+  OPENSUSE_UNOFFICIAL_LIBCONTAINERS_KEY_URL: "https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/unstable/xUbuntu_22.04/Release.key"
+  OPENSUSE_UNOFFICIAL_LIBCONTAINERS_SOURCE_URL: "https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/unstable/xUbuntu_22.04"
+
+jobs:
+  build-web:
+    name: Build web server image
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
+    steps:
+    - name: Install podman v4
+      run: |
+        echo "deb $OPENSUSE_UNOFFICIAL_LIBCONTAINERS_SOURCE_URL/ /" | sudo tee /etc/apt/sources.list.d/devel:kubic:libcontainers:unstable.list
+        curl -fsSL $OPENSUSE_UNOFFICIAL_LIBCONTAINERS_KEY_URL | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/devel_kubic_libcontainers_unstable.gpg > /dev/null
+        sudo apt -y purge podman
+        sudo apt update && sudo apt -y install podman
+    - uses: actions/checkout@v4
+      with:
+        token: ${{ github.token }}
+    - name: Build web server image
+      run: |
+        cd app/front-end && make oci-build
+    - name: Tag image
+      id: tag-image
+      run: |
+        cd app/front-end && IMG_TAG="$(make --eval='print-img-ver: ; @echo $(IMAGE_VERSION)' print-img-ver)"
+        echo "tags=$IMG_TAG" >> $GITHUB_OUTPUT
+    - name: Push to ghcr.io
+      id: push-to-ghrc
+      uses: redhat-actions/push-to-registry@v2
+      with:
+        image: privacypal
+        tags: ${{ steps.tag-image.outputs.tags }}
+        registry: ghcr.io/cosc-499-w2023
+        username: team1
+        password: ${{ secrets.GITHUB_TOKEN }}
+    - name: Print image url
+      run: echo "Image pushed to ${{ steps.push-to-ghrc.outputs.registry-paths }}"
+
+  build-video-processor:
+    name: Build video processing server image
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
+    steps:
+    - name: Install podman v4
+      run: |
+        echo "deb $OPENSUSE_UNOFFICIAL_LIBCONTAINERS_SOURCE_URL/ /" | sudo tee /etc/apt/sources.list.d/devel:kubic:libcontainers:unstable.list
+        curl -fsSL $OPENSUSE_UNOFFICIAL_LIBCONTAINERS_KEY_URL | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/devel_kubic_libcontainers_unstable.gpg > /dev/null
+        sudo apt -y purge podman
+        sudo apt update && sudo apt -y install podman
+    - uses: actions/checkout@v4
+      with:
+        token: ${{ github.token }}
+    - name: Build video processor image
+      run: |
+        cd app/back-end/video-processing && make oci-build
+    - name: Tag image
+      id: tag-image
+      run: |
+        cd app/back-end/video-processing && IMG_TAG="$(make --eval='print-img-ver: ; @echo $(IMAGE_VERSION)' print-img-ver)"
+        echo "tags=$IMG_TAG" >> $GITHUB_OUTPUT
+    - name: Push to ghcr.io
+      id: push-to-ghrc
+      uses: redhat-actions/push-to-registry@v2
+      with:
+        image: privacypal-vidprocess
+        tags: ${{ steps.tag-image.outputs.tags }}
+        registry: ghcr.io/cosc-499-w2023
+        username: team1
+        password: ${{ secrets.GITHUB_TOKEN }}
+    - name: Print image url
+      run: echo "Image pushed to ${{ steps.push-to-ghrc.outputs.registry-paths }}"
+
+  build-db-init:
+    name: Build database initialize image
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
+    steps:
+    - name: Install podman v4
+      run: |
+        echo "deb $OPENSUSE_UNOFFICIAL_LIBCONTAINERS_SOURCE_URL/ /" | sudo tee /etc/apt/sources.list.d/devel:kubic:libcontainers:unstable.list
+        curl -fsSL $OPENSUSE_UNOFFICIAL_LIBCONTAINERS_KEY_URL | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/devel_kubic_libcontainers_unstable.gpg > /dev/null
+        sudo apt -y purge podman
+        sudo apt update && sudo apt -y install podman
+    - uses: actions/checkout@v4
+      with:
+        token: ${{ github.token }}
+    - name: Build database init image
+      run: |
+        cd app/front-end/db && make oci-build
+    - name: Tag image
+      id: tag-image
+      run: |
+        cd app/front-end/db && IMG_TAG="$(make --eval='print-img-ver: ; @echo $(IMAGE_VERSION)' print-img-ver)"
+        echo "tags=$IMG_TAG" >> $GITHUB_OUTPUT
+    - name: Push to ghcr.io
+      id: push-to-ghrc
+      uses: redhat-actions/push-to-registry@v2
+      with:
+        image: privacypal-init-db
+        tags: ${{ steps.tag-image.outputs.tags }}
+        registry: ghcr.io/cosc-499-w2023
+        username: team1
+        password: ${{ secrets.GITHUB_TOKEN }}
+    - name: Print image url
+      run: echo "Image pushed to ${{ steps.push-to-ghrc.outputs.registry-paths }}"


### PR DESCRIPTION
## What's new

CI to build container images and push to `ghcr.io` registry on push events. This will handle push evens on both development and production (upstream).

Fixes #8

## Note

This PR includes push even for `gh-8-build-ci` for showing CI is working. Will remove after approval.

```yaml
      - "gh-8-build-ci" # FIXME: remove after PR is approved
``` 