### PR TITLE
fix(release): fix tag name for release v0.1.0-alpha.1

### DIFF
--- a/app/smoketest/compose/privacypal.yaml
+++ b/app/smoketest/compose/privacypal.yaml
@@ -2,7 +2,7 @@ version: "3"
 
 services:
   privacypal:
-    image: ghcr.io/cosc-499-w2023/privacypal:v0.1.0-alpha.1
+    image: ghcr.io/cosc-499-w2023/privacypal:0.1.0-alpha.1
     build: ../../web/
     user: "0"
     depends_on:
@@ -34,7 +34,7 @@ services:
     restart: unless-stopped
 
   video-processor:
-    image: ghcr.io/cosc-499-w2023/privacypal-vidprocess:v0.1.0-alpha.1
+    image: ghcr.io/cosc-499-w2023/privacypal-vidprocess:0.1.0-alpha.1
     build: ../../video-processing
     user: "0"
     networks:
@@ -83,7 +83,7 @@ services:
       timeout: 5s
 
   db-init:
-    image: ghcr.io/cosc-499-w2023/privacypal-init-db:v0.1.0-alpha.1
+    image: ghcr.io/cosc-499-w2023/privacypal-init-db:0.1.0-alpha.1
     depends_on:
       db:
         condition: service_healthy

--- a/app/video-processing/Makefile
+++ b/app/video-processing/Makefile
@@ -4,7 +4,7 @@ SHELL := /usr/bin/env bash -o pipefail
 .SHELLFLAGS = -ec
 
 # Image identifier
-IMAGE_VERSION ?= v0.1.0-alpha.1
+IMAGE_VERSION ?= 0.1.0-alpha.1
 IMAGE_NAME ?= privacypal-vidprocess
 DEFAULT_NAMESPACE = ghcr.io/cosc-499-w2023
 IMAGE_NAMESPACE ?= $(DEFAULT_NAMESPACE)

--- a/app/web/Makefile
+++ b/app/web/Makefile
@@ -4,7 +4,7 @@ SHELL := /usr/bin/env bash -o pipefail
 .SHELLFLAGS = -ec
 
 # Image identifier
-IMAGE_VERSION ?= v0.1.0-alpha.1
+IMAGE_VERSION ?= 0.1.0-alpha.1
 IMAGE_NAME ?= privacypal
 DEFAULT_NAMESPACE = ghcr.io/cosc-499-w2023
 IMAGE_NAMESPACE ?= $(DEFAULT_NAMESPACE)

--- a/app/web/db/Makefile
+++ b/app/web/db/Makefile
@@ -19,7 +19,7 @@ export DATABASE_URL=postgresql://$(DATABASE_USER):$(DATABASE_PASSWORD)@$(DATABAS
 IMAGE_BUILDER ?= podman
 
 # Image identifier
-IMAGE_VERSION ?= v0.1.0-alpha.1
+IMAGE_VERSION ?= 0.1.0-alpha.1
 IMAGE_NAME ?= privacypal-init-db
 DEFAULT_NAMESPACE = ghcr.io/cosc-499-w2023
 IMAGE_NAMESPACE ?= $(DEFAULT_NAMESPACE)

--- a/app/web/package-lock.json
+++ b/app/web/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "privacypal",
-    "version": "v0.1.0-alpha.1",
+    "version": "0.1.0-alpha.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "privacypal",
-            "version": "v0.1.0-alpha.1",
+            "version": "0.1.0-alpha.1",
             "dependencies": {
                 "@patternfly/react-core": "^5.1.1",
                 "@patternfly/react-icons": "^5.1.1",

--- a/app/web/package.json
+++ b/app/web/package.json
@@ -1,6 +1,6 @@
 {
     "name": "privacypal",
-    "version": "v0.1.0-alpha.1",
+    "version": "0.1.0-alpha.1",
     "private": true,
     "scripts": {
         "start:dev": "PORT=${PORT:-8081} next dev",


### PR DESCRIPTION
# Welcome to PrivacyPal! 👋

Related to #81 

## Description of the change:

Remove prefix `v` from image tag.

## Motivation for the change:

This follow best practices for tagging container images `registry/namespace/image:0.1.0`.
