### PR TITLE
fix(dependabot): select develop as target branch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,6 +2,7 @@ version: 2
 updates:
   - package-ecosystem: "npm"
     directory: "/app/web"
+    target-branch: "develop"
     schedule:
       interval: "daily"
     labels:
@@ -9,6 +10,7 @@ updates:
       - "chore"
   - package-ecosystem: "pip"
     directory: "/app/video-processing"
+    target-branch: "develop"
     schedule:
       interval: "daily"
     labels:


### PR DESCRIPTION
# Welcome to PrivacyPal! 👋

Related to #18 

## Description of the change:

Select `develop` as target branch.

## Motivation for the change:

So that we don't have to manually change the base branch.