### PR TITLE
ci(cache): cache deps for CI workflows

### DIFF
--- a/.github/workflows/nextjs-test-ci.yaml
+++ b/.github/workflows/nextjs-test-ci.yaml
@@ -20,15 +20,17 @@ jobs:
   unit-test:
     runs-on: ubuntu-latest
     steps:
-    - name: Set up Node
-      uses: actions/setup-node@v4
-      with:
-        node-version: '18'
     - name: Check out the repository
       uses: actions/checkout@v4
       with:
         token: ${{ github.token }}
+    - name: Set up Node
+      uses: actions/setup-node@v4
+      with:
+        node-version: '18'
     - name: Install dependencies
-      run: cd app/web && npm ci
+      uses: bahmutov/npm-install@v1
+      with:
+        working-directory: app/web
     - name: Run tests
       run: cd app/web && npm run test

--- a/.github/workflows/vidserver-test-ci.yaml
+++ b/.github/workflows/vidserver-test-ci.yaml
@@ -20,14 +20,16 @@ jobs:
   unit-test:
     runs-on: ubuntu-latest
     steps:
-    - name: Set up Python
-      uses: actions/setup-python@v4
-      with:
-        python-version: '3.8' 
     - name: Check out the repository
       uses: actions/checkout@v4
       with:
         token: ${{ github.token }}
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.8'
+        cache: 'pip'
+        cache-dependency-path: "**/requirements.txt"
     - name: Install dependencies
       run: pip install -r app/video-processing/requirements.txt
     - name: Run tests


### PR DESCRIPTION
# Welcome to PrivacyPal! 👋

Fixes: #146 

## Description of the change:

Cache dependencies for CI. This enable resuable cache if cache is hit (i.e. deps manifest files have not changed).

## Motivation for the change:

Caching allows quicker CI runs by avoiding fresh installation of deps.
