### PR TITLE
fix(videos): do not clean up input videos when cancelling

### DIFF
--- a/app/video-processing/server.py
+++ b/app/video-processing/server.py
@@ -74,8 +74,7 @@ async def cancel_process():
         process.kill()
 
         # cleanup files that may or may not exist as a result of cancelling a video processing operation
-        for f in [f"{app.config['INPUT_DIR']}/{file}",
-                  f"{app.config['OUTPUT_DIR']}/{file[:-4]}-processed{file[-4:]}",
+        for f in [f"{app.config['OUTPUT_DIR']}/{file[:-4]}-processed{file[-4:]}",
                   f"{app.config['OUTPUT_DIR']}/{file[:-4]}-processed-temp{file[-4:]}"]:
             if os.path.isfile(f):
                 os.remove(f)


### PR DESCRIPTION
# Welcome to PrivacyPal! 👋

Related to #171 

## Description of the change:


Cancelling cleanup should ignore input files.

## Motivation for the change:

Retrying processing (same video) can just reuse the same input files. NextJS can do the clean up when the video is accepted or rejected.
