### PR TITLE
fix(auth): remove check for AUTH_SECRET at build time

### DIFF
--- a/app/web/src/lib/config.ts
+++ b/app/web/src/lib/config.ts
@@ -21,6 +21,3 @@ export const extractBasicUserRecords = () => {
 export const configError = (message: string): Error => {
     throw new Error(`[PrivacyPalConfig]: ${message}`);
 };
-
-// if no auth secret is provided, throw an error at runtime
-if (!AUTH_SECRET) configError("AUTH_SECRET must be defined.");


### PR DESCRIPTION
# Welcome to PrivacyPal! 👋

Related to #126 

## Description of the change:

Removed check for Auth Secret at build time.
## Motivation for the change:

NextJS attempts to pre-build certain pages, which causes the module to be executed. At build time, the variable is not available, thus build failed.

Reference: https://github.com/COSC-499-W2023/year-long-project-team-1/actions/runs/7029364190/job/19126855375