### PR TITLE
fix(build): force /api/users/clients to be dynamic

### DIFF
--- a/app/web/src/app/api/users/clients/route.ts
+++ b/app/web/src/app/api/users/clients/route.ts
@@ -6,6 +6,8 @@
 import { getClients } from "@app/actions";
 import { JSONResponse, RESPONSE_NOT_FOUND } from "@lib/response";
 
+export const dynamic = "force-dynamic";
+
 export async function GET(req: Request) {
     const clients = await getClients();
 


### PR DESCRIPTION
# Welcome to PrivacyPal! 👋

Fixes: #239

## Description of the change:

Exported `const dynamic = 'force-dynamic'` from `/api/users/clients`

## Motivation for the change:

Container build fails when prerendering this route without a database available.
