### PR TITLE
build(next): add build info as public resource

### DIFF
--- a/app/web/Dockerfile
+++ b/app/web/Dockerfile
@@ -39,7 +39,6 @@ RUN mkdir .next && chown nextjs .next
 # https://nextjs.org/docs/advanced-features/output-file-tracing
 COPY --from=builder --chown=nextjs /app/.next/standalone ./
 COPY --from=builder --chown=nextjs /app/.next/static ./.next/static
-# COPY --from=builder /app/public ./public
 
 USER nextjs
 

--- a/app/web/public/build.json
+++ b/app/web/public/build.json
@@ -1,0 +1,4 @@
+{
+    "version": "0.1.0-dev",
+    "productName": "privacypal"
+}

--- a/app/web/src/app/health/route.ts
+++ b/app/web/src/app/health/route.ts
@@ -13,10 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { PRIVACYPAL_VERSION } from "@lib/config";
-import prisma from "@lib/db";
+import build from "@public/build.json";
+import db from "@lib/db";
 import { JSONResponse } from "@lib/response";
-import { client, testS3Connection } from "@lib/s3";
+import { testS3Connection } from "@lib/s3";
+
+export const dynamic = "force-dynamic";
 
 /* Video processing */
 
@@ -38,7 +40,7 @@ async function checkVideoProcessor(): Promise<boolean> {
 
 async function checkPostgres(): Promise<boolean> {
   try {
-    await prisma.$connect();
+    await db.$connect();
     return true;
   } catch (err: any) {
     return false;
@@ -60,7 +62,7 @@ export async function GET() {
 
   const response: JSONResponse = {
     data: {
-      app_version: PRIVACYPAL_VERSION,
+      app_version: build.version,
       video_processor_available: videoProcessorAlive,
       database_available: databaseAlive,
       video_storage_available: s3Alive,

--- a/app/web/tsconfig.json
+++ b/app/web/tsconfig.json
@@ -30,7 +30,8 @@
       "@patternfly/assets/*": [
         "node_modules/@patternfly/react-core/dist/styles/assets/*"
       ],
-      "@conf/*": ["./conf/*"]
+      "@conf/*": ["./conf/*"],
+      "@public/*": ["./public/*"]
     }
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],


### PR DESCRIPTION
# Welcome to PrivacyPal! 👋

Fixes: #356 

## Description of the change:

Added `build.json` containing product build information. Also, fix broken `/health` endpoint when attempting to build container image.

## Motivation for the change:

See #356 


## Sample runs

If you are interested, the http client I used is https://httpie.io/. Basically, a nicer `curl`.

```
$ http :8080/health
HTTP/1.1 200 OK
Connection: keep-alive
Date: Fri, 19 Jan 2024 04:52:17 GMT
Keep-Alive: timeout=5
Transfer-Encoding: chunked
content-type: application/json
vary: RSC, Next-Router-State-Tree, Next-Router-Prefetch, Next-Url

{
    "data": {
        "app_version": "0.1.0-dev",
        "database_available": false,
        "video_processor_available": false,
        "video_storage_available": true
    }
}


$ http :8080/build.json
HTTP/1.1 200 OK
Accept-Ranges: bytes
Cache-Control: public, max-age=0
Connection: keep-alive
Content-Length: 64
Content-Type: application/json; charset=UTF-8
Date: Fri, 19 Jan 2024 04:52:29 GMT
ETag: W/"40-18d200f92a0"
Keep-Alive: timeout=5
Last-Modified: Fri, 19 Jan 2024 04:51:48 GMT
Vary: Accept-Encoding

{
    "productName": "privacypal",
    "version": "0.1.0-dev"
}
```