### PR TITLE
ci(ecr): push container images to AWS ECR

### DIFF
--- a/.github/workflows/build-ci.yaml
+++ b/.github/workflows/build-ci.yaml
@@ -13,16 +13,19 @@ on:
   workflow_dispatch:
 
 env:
+  AWS_REGION: ca-central-1
   OPENSUSE_UNOFFICIAL_LIBCONTAINERS_KEY_URL: "https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/unstable/xUbuntu_22.04/Release.key"
   OPENSUSE_UNOFFICIAL_LIBCONTAINERS_SOURCE_URL: "https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/unstable/xUbuntu_22.04"
+
+permissions:
+  packages: write
+  contents: read
+  id-token: write # Required for requesting the JWT
 
 jobs:
   build-web:
     name: Build web server image
     runs-on: ubuntu-latest
-    permissions:
-      packages: write
-      contents: read
     steps:
     - name: Install podman v4
       run: |
@@ -33,33 +36,36 @@ jobs:
     - uses: actions/checkout@v4
       with:
         token: ${{ github.token }}
+    - name: Configure AWS credentials
+      uses: aws-actions/configure-aws-credentials@v3
+      with:
+        role-to-assume: ${{ secrets.AWS_GITHUB_ROLE_ARN }}
+        aws-region: ${{ env.AWS_REGION }}
     - name: Build web server image
       working-directory: app/web
-      run: make oci-build
-    - name: Tag image
-      id: tag-image
+      run: | 
+        IMAGE_NAMESPACE="${{ secrets.AWS_ECR_REPO_BASE }}" make oci-build
+    - name: Get image tag
+      id: get-image-tag
       working-directory: app/web
       run: |
         IMG_TAG="$(make --eval='print-img-ver: ; @echo $(IMAGE_VERSION)' print-img-ver)"
         echo "tags=$IMG_TAG" >> $GITHUB_OUTPUT
-    - name: Push to ghcr.io
-      id: push-to-ghrc
+    - name: Login to Amazon ECR
+      uses: aws-actions/amazon-ecr-login@v2
+      with:
+        mask-password: true
+    - name: Push to AWS ECR
+      id: push-to-ecr
       uses: redhat-actions/push-to-registry@v2
       with:
         image: privacypal
-        tags: ${{ steps.tag-image.outputs.tags }}
-        registry: ghcr.io/cosc-499-w2023
-        username: team1
-        password: ${{ secrets.GITHUB_TOKEN }}
-    - name: Print image url
-      run: echo "Image pushed to ${{ steps.push-to-ghrc.outputs.registry-paths }}"
+        tags: ${{ steps.get-image-tag.outputs.tags }}
+        registry: ${{ secrets.AWS_ECR_REPO_BASE }}
 
   build-video-processor:
     name: Build video processing server image
     runs-on: ubuntu-latest
-    permissions:
-      packages: write
-      contents: read
     steps:
     - name: Install podman v4
       run: |
@@ -70,33 +76,76 @@ jobs:
     - uses: actions/checkout@v4
       with:
         token: ${{ github.token }}
+    - name: Configure AWS credentials
+      uses: aws-actions/configure-aws-credentials@v3
+      with:
+        role-to-assume: ${{ secrets.AWS_GITHUB_ROLE_ARN }}
+        aws-region: ${{ env.AWS_REGION }}
     - name: Build video processor image
       working-directory: app/video-processing
-      run: make oci-build
-    - name: Tag image
-      id: tag-image
+      run: |
+        IMAGE_NAMESPACE="${{ secrets.AWS_ECR_REPO_BASE }}" make oci-build
+    - name: Get image tag
+      id: get-image-tag
       working-directory: app/video-processing
       run: |
         IMG_TAG="$(make --eval='print-img-ver: ; @echo $(IMAGE_VERSION)' print-img-ver)"
         echo "tags=$IMG_TAG" >> $GITHUB_OUTPUT
-    - name: Push to ghcr.io
-      id: push-to-ghrc
+    - name: Login to Amazon ECR
+      uses: aws-actions/amazon-ecr-login@v2
+      with:
+        mask-password: true
+    - name: Push to AWS ECR
+      id: push-to-ecr
       uses: redhat-actions/push-to-registry@v2
       with:
         image: privacypal-vidprocess
-        tags: ${{ steps.tag-image.outputs.tags }}
-        registry: ghcr.io/cosc-499-w2023
-        username: team1
-        password: ${{ secrets.GITHUB_TOKEN }}
-    - name: Print image url
-      run: echo "Image pushed to ${{ steps.push-to-ghrc.outputs.registry-paths }}"
+        tags: ${{ steps.get-image-tag.outputs.tags }}
+        registry: ${{ secrets.AWS_ECR_REPO_BASE }}
+
+  build-video-processor-lambda:
+    name: Build video processing server Lambda image
+    runs-on: ubuntu-latest
+    steps:
+    - name: Install podman v4
+      run: |
+        echo "deb $OPENSUSE_UNOFFICIAL_LIBCONTAINERS_SOURCE_URL/ /" | sudo tee /etc/apt/sources.list.d/devel:kubic:libcontainers:unstable.list
+        curl -fsSL $OPENSUSE_UNOFFICIAL_LIBCONTAINERS_KEY_URL | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/devel_kubic_libcontainers_unstable.gpg > /dev/null
+        sudo apt -y purge podman
+        sudo apt update && sudo apt -y install podman
+    - uses: actions/checkout@v4
+      with:
+        token: ${{ github.token }}
+    - name: Configure AWS credentials
+      uses: aws-actions/configure-aws-credentials@v3
+      with:
+        role-to-assume: ${{ secrets.AWS_GITHUB_ROLE_ARN }}
+        aws-region: ${{ env.AWS_REGION }}
+    - name: Build video processor Lambda image
+      working-directory: app/video-processing
+      run: |
+        IMAGE_NAMESPACE="${{ secrets.AWS_ECR_REPO_BASE }}" make lambda-oci-build
+    - name: Get image tag
+      id: get-image-tag
+      working-directory: app/video-processing
+      run: |
+        IMG_TAG="$(make --eval='print-img-ver: ; @echo $(IMAGE_VERSION)' print-img-ver)"
+        echo "tags=$IMG_TAG" >> $GITHUB_OUTPUT
+    - name: Login to Amazon ECR
+      uses: aws-actions/amazon-ecr-login@v2
+      with:
+        mask-password: true
+    - name: Push to AWS ECR
+      id: push-to-ecr
+      uses: redhat-actions/push-to-registry@v2
+      with:
+        image: privacypal-vidproc-lambda
+        tags: ${{ steps.get-image-tag.outputs.tags }}
+        registry: ${{ secrets.AWS_ECR_REPO_BASE }}
 
   build-db-init:
     name: Build database initialize image
     runs-on: ubuntu-latest
-    permissions:
-      packages: write
-      contents: read
     steps:
     - name: Install podman v4
       run: |
@@ -107,23 +156,29 @@ jobs:
     - uses: actions/checkout@v4
       with:
         token: ${{ github.token }}
+    - name: Configure AWS credentials
+      uses: aws-actions/configure-aws-credentials@v3
+      with:
+        role-to-assume: ${{ secrets.AWS_GITHUB_ROLE_ARN }}
+        aws-region: ${{ env.AWS_REGION }}
     - name: Build database init image
       working-directory: app/web/db
-      run: make oci-build
-    - name: Tag image
-      id: tag-image
+      run: |
+        IMAGE_NAMESPACE="${{ secrets.AWS_ECR_REPO_BASE }}" make oci-build
+    - name: Get image tag
+      id: get-image-tag
       working-directory: app/web/db
       run: |
         IMG_TAG="$(make --eval='print-img-ver: ; @echo $(IMAGE_VERSION)' print-img-ver)"
         echo "tags=$IMG_TAG" >> $GITHUB_OUTPUT
-    - name: Push to ghcr.io
-      id: push-to-ghrc
+    - name: Login to Amazon ECR
+      uses: aws-actions/amazon-ecr-login@v2
+      with:
+        mask-password: true
+    - name: Push to AWS ECR
+      id: push-to-ecr
       uses: redhat-actions/push-to-registry@v2
       with:
         image: privacypal-init-db
-        tags: ${{ steps.tag-image.outputs.tags }}
-        registry: ghcr.io/cosc-499-w2023
-        username: team1
-        password: ${{ secrets.GITHUB_TOKEN }}
-    - name: Print image url
-      run: echo "Image pushed to ${{ steps.push-to-ghrc.outputs.registry-paths }}"
+        tags: ${{ steps.get-image-tag.outputs.tags }}
+        registry: ${{ secrets.AWS_ECR_REPO_BASE }}


### PR DESCRIPTION
# Welcome to PrivacyPal! 👋

Fixes: #364 

## Description of the change:

- Updated build CI to push container images to a private AWS ECR.
- The setup involved configuring AWS IAM OIDC provider and IAM role for short-term credential requests. With that, 2 repository secrets are added:
  - `AWS_GITHUB_ROLE_ARN`: The IAM Role identifier that the github action can assume. This role has sufficient permissions to pull/push to a private ECR.
  - `AWS_ECR_REPO_BASE`: The base/prefix of the private ECR repositories.

## Motivation for the change:

Since we now have to maintain the lambda image on AWS ECR, it would avoid the heavy work to maintain images on 2 sources (i.e. ghcr.io and ECR).

With the image on ECR, we can look into some CI workflow to continuously deploy components on k8s and aws for smoketests and QA.
