### PR TITLE
chore(s3): remove bucket default names

### DIFF
--- a/app/web/src/lib/s3.ts
+++ b/app/web/src/lib/s3.ts
@@ -26,11 +26,11 @@ export async function getRegion() {
 }
 
 export function getOutputBucket() {
-  return process.env.PRIVACYPAL_OUTPUT_BUCKET || "privacypal-output";
+  return process.env.PRIVACYPAL_OUTPUT_BUCKET || "";
 }
 
 export function getTmpBucket() {
-  return process.env.PRIVACYPAL_TMP_BUCKET || "privacypal-input";
+  return process.env.PRIVACYPAL_TMP_BUCKET || "";
 }
 
 export function generateObjectKey(filename: string, userId: string) {


### PR DESCRIPTION
# Welcome to PrivacyPal! 👋

Related to #361 

## Description of the change:

Remove bucket default names. The bucket names must be specified when deploying the application.

## Motivation for the change:

This originated from the confusions we have during #388 whether which buckets (tmp or input) are being referred to. Besides, this helps avoid giving the impression that NextJS might try to access a bucket that it does not actually have access to.
