### PR TITLE
test(login): scaffold login command

### DIFF
--- a/app/web/cypress.env.json
+++ b/app/web/cypress.env.json
@@ -1,0 +1,7 @@
+{
+  "PRIVACYPAL_AUTH_MANAGER": "basic",
+  "PRIVACYPAL_TEST_USERNAME_BASIC": "testuser1",
+  "PRIVACYPAL_TEST_PASSWORD_BASIC": "password",
+  "PRIVACYPAL_TEST_SITE_URL": "http://localhost:3000",
+  "PRIVACYPAL_AUTH_COOKIE_NAME": "next-auth.session-token"
+}

--- a/app/web/cypress/e2e/api/users.cy.ts
+++ b/app/web/cypress/e2e/api/users.cy.ts
@@ -16,6 +16,8 @@
 
 describe("/api/users: Fetch users", () => {
   it("Should return a list of users", () => {
+    cy.loginAsTest();
+
     cy.request("/api/users").then((response) => {
       expect(response.status).to.eq(200);
       expect(response.body).to.have.property("result");

--- a/app/web/cypress/support/commands.ts
+++ b/app/web/cypress/support/commands.ts
@@ -1,0 +1,18 @@
+Cypress.Commands.add("loginAsTest", () => {
+  const username = Cypress.env("PRIVACYPAL_TEST_USERNAME_BASIC");
+  const password = Cypress.env("PRIVACYPAL_TEST_PASSWORD_BASIC");
+  const loginUrl = Cypress.env("PRIVACYPAL_TEST_SITE_URL");
+  const cookieName = Cypress.env("PRIVACYPAL_AUTH_COOKIE_NAME");
+
+  cy.request("/api/auth/signin", {
+    method: "POST",
+    body: {
+      username,
+      password,
+    },
+  }).then((response) => {
+    cy.clearCookies();
+
+    const cookies = response.headers["set-cookie"];
+  });
+});

--- a/app/web/cypress/support/index.d.ts
+++ b/app/web/cypress/support/index.d.ts
@@ -1,0 +1,9 @@
+declare namespace Cypress {
+  interface Chainable {
+    /**
+     * Custom command to log in a user.
+     * @example cy.login('username', 'password')
+     */
+    loginAsTest(): Chainable<void>;
+  }
+}


### PR DESCRIPTION
# Welcome to PrivacyPal! 👋

Fixes: #475

## Description of the change:
This provides a Cypress command that allows anyone to log in easily from any test they write that may need auth for middleware routing purposes.

## Motivation for the change:
Need to be able to test protected routes' features.
