### PR TITLE
chore(deps): bump botocore to 1.34.38

### DIFF
--- a/app/video-processing/lambda/requirements.txt
+++ b/app/video-processing/lambda/requirements.txt
@@ -1,4 +1,4 @@
 boto3==1.34.38
-botocore==1.34.37
+botocore==1.34.38
 numpy==1.26.4
 opencv-python-headless==4.9.0.80


### PR DESCRIPTION
# Welcome to PrivacyPal! 👋

Related to #501 

## Description of the change:

Bump botocore 1.34.38 to match boto3.

## Motivation for the change:

Broken image build.

https://github.com/COSC-499-W2023/year-long-project-team-1/actions/runs/7836930614/job/21385582293