### PR TITLE
chore(backend): removed '-processed' suffixes for readability

### DIFF
--- a/app/video-processing/lambda/lambda.py
+++ b/app/video-processing/lambda/lambda.py
@@ -33,7 +33,7 @@ def lambda_handler(event, context):
     s3object = s3.get_object(Bucket=bucket, Key=filekey)
     data = s3object.get("Body").read()
     input_filepath = f"/tmp/{filekey}"
-    output_filepath = f"{input_filepath[:-4]}-processed{input_filepath[-4:]}"
+    output_filepath = f"{input_filepath[:-4]}-processed{input_filepath[-4:]}"   # only locally named this, S3 output bucket will be `filekey`
     with open(input_filepath, "wb") as f:
         f.write(data)
 
@@ -51,7 +51,7 @@ def lambda_handler(event, context):
     vp.process(input_filepath, output_filepath, regions, blur_faces)
 
     s3.upload_file(output_filepath, OUTPUT_BUCKET,
-                   f"{filekey[:-4]}-processed{filekey[-4:]}",
+                   f"{filekey}",
                    ExtraArgs={"Tagging": "privacypal-status=UnderReview"})
 
     return {

--- a/app/web/src/components/VideoReview.tsx
+++ b/app/web/src/components/VideoReview.tsx
@@ -45,7 +45,7 @@ interface VideoReviewProps {
 export const VideoReview = ({ videoId }: VideoReviewProps) => {
   // const router = useRouter();
 
-  const videoFilename = videoId.replace(".mp4", "") + "-processed.mp4";
+  const videoFilename = videoId;
 
   const handleVideoRequest = async (action: string) => {
     const successMsg =


### PR DESCRIPTION
# Welcome to PrivacyPal! 👋

Fixes: #503 

## Description of the change:
Removes '-processed' suffix for readability and simplicity now that we don't need it anymore.

## Motivation for the change:
More human readable code and removes unnecessary data