### PR TITLE
fix(health): health endpoint should be public

### DIFF
--- a/app/web/src/app/health/liveness/route.ts
+++ b/app/web/src/app/health/liveness/route.ts
@@ -14,5 +14,5 @@
  * limitations under the License.
  */
 export async function GET() {
-  return new Response(null, { status: 204 });
+  return new Response(null, { status: 200 });
 }

--- a/app/web/src/middleware.ts
+++ b/app/web/src/middleware.ts
@@ -15,11 +15,9 @@
  */
 "use server";
 
-import { NextRequest, NextResponse } from "next/server";
-
-import { auth } from "./auth";
-import { NextAuthOptions, User, getServerSession } from "next-auth";
-import { NextAuthMiddlewareOptions, withAuth } from "next-auth/middleware";
+import { NextResponse } from "next/server";
+import { User } from "next-auth";
+import { withAuth } from "next-auth/middleware";
 import { Role } from "@prisma/client";
 
 // possible protected paths
@@ -85,5 +83,5 @@ export default withAuth(
 
 export const config = {
   matcher:
-    "/((?!api/auth|login|logout|signup|_next/static|_next/image|favicon.ico).+)",
+    "/((?!api/auth|login|logout|signup|_next/static|_next/image|favicon.ico|build.json|health).+)",
 };


### PR DESCRIPTION
# Welcome to PrivacyPal! 👋

Fixes: #500 

## Description of the change:

Make health endpoints and `build.json` public. Also, have to switch `/health/liveness` to return 200 as 204 causes internal server error within NextJS.

```
$ http :8080/build.json
HTTP/1.1 200 OK
Accept-Ranges: bytes
Cache-Control: public, max-age=0
Connection: keep-alive
Content-Length: 64
Content-Type: application/json; charset=UTF-8
Date: Tue, 13 Feb 2024 08:13:21 GMT
ETag: W/"40-18da186af58"
Keep-Alive: timeout=5
Last-Modified: Tue, 13 Feb 2024 08:12:55 GMT
Vary: Accept-Encoding

{
    "productName": "privacypal",
    "version": "0.1.0-dev"
}
```

```
$ http :8080/health
HTTP/1.1 200 OK
Connection: keep-alive
Date: Tue, 13 Feb 2024 08:15:36 GMT
Keep-Alive: timeout=5
Transfer-Encoding: chunked
content-type: application/json
vary: RSC, Next-Router-State-Tree, Next-Router-Prefetch, Next-Url

{
    "data": {
        "app_version": "0.1.0-dev",
        "database_available": true,
        "video_processor_available": true,
        "video_storage_available": true
    }
}
```

```
$ http :8080/health/liveness
HTTP/1.1 200 OK
Connection: keep-alive
Date: Tue, 13 Feb 2024 08:16:02 GMT
Keep-Alive: timeout=5
Transfer-Encoding: chunked
vary: RSC, Next-Router-State-Tree, Next-Router-Prefetch, Next-Url
x-nextjs-cache: HIT
```

## Motivation for the change:

This ensures health checks can be performed without having to logging in (i.e. k8s health check, helm chart connection check)
