### PR TITLE
build(oci): container image should specific numeric user

### DIFF
--- a/app/web/Dockerfile
+++ b/app/web/Dockerfile
@@ -28,7 +28,7 @@ ENV CONFIG_DIR=/opt/privacypal
 
 RUN mkdir -p $CONFIG_DIR && chmod -R g=u $CONFIG_DIR
 
-RUN adduser --system --ingroup root nextjs
+RUN adduser --system --ingroup root --uid 1001 nextjs
 
 WORKDIR /app
 
@@ -40,7 +40,7 @@ RUN mkdir .next && chown nextjs .next
 COPY --from=builder --chown=nextjs /app/.next/standalone ./
 COPY --from=builder --chown=nextjs /app/.next/static ./.next/static
 
-USER nextjs
+USER 1001
 
 EXPOSE 8080
 

--- a/app/web/db/Dockerfile
+++ b/app/web/db/Dockerfile
@@ -5,7 +5,7 @@ USER root
 # Reference: https://github.com/nodejs/docker-node/tree/b4117f9333da4138b03a546ec926ef50a31506c3#nodealpine
 RUN apk add --no-cache libc6-compat
 
-RUN adduser --system --ingroup root prisma
+RUN adduser --system --ingroup root --uid 1002 prisma
 
 RUN npm install -g prisma@5.9.1
 
@@ -13,6 +13,6 @@ WORKDIR /app
 
 COPY . .
 
-USER prisma
+USER 1002
 
 ENTRYPOINT ["sh", "include/entrypoint.sh"]


### PR DESCRIPTION
# Welcome to PrivacyPal! 👋

Related to #5 

## Description of the change:

Specify non-root user as UID.

## Motivation for the change:

Container image should specific numeric user to allow `runAsNonRoot` on k8s.

```
Warning  Failed     11m (x8 over 12m)    kubelet            Error: container has runAsNonRoot and image has non-numeric user (prisma), cannot verify user is non-root (pod: "k8s-smoketest-privacypal-556b5d756f-cvc8v_privacypal-app(e5c15277-ff23-45e9-bdab-1e65180b0b65)", container: privacypal-database-init)
```
