### PR TITLE
feat(auth): bypass cognito login with tricks

### DIFF
--- a/app/web/src/app/login/page.tsx
+++ b/app/web/src/app/login/page.tsx
@@ -14,8 +14,11 @@
  * limitations under the License.
  */
 
+import { LoginBypass } from "@components/auth/LoginBypass";
 import LoginFlow from "@components/auth/LoginFlow";
+import { LoginLogout } from "@components/auth/button/LoginLogout";
 import React, { Suspense } from "react";
+import { authManager } from "src/auth";
 
 export const dynamic = "force-dynamic";
 
@@ -26,9 +29,11 @@ const LoginFallback = () => {
 export default function LoginPage() {
   return (
     <main>
-      <Suspense fallback={<LoginFallback />}>
+      {/* <Suspense fallback={<LoginFallback />}>
         <LoginFlow />
-      </Suspense>
+      </Suspense> */}
+      {/* <LoginLogout /> */}
+      <LoginBypass authManager={authManager} />
     </main>
   );
 }

--- a/app/web/src/app/page.tsx
+++ b/app/web/src/app/page.tsx
@@ -21,6 +21,7 @@ import { redirect } from "next/navigation";
 import { getUserHubSlug } from "@lib/utils";
 import { LoginButton } from "@components/auth/button/LoginButton";
 import { authManager } from "src/auth";
+import LinkButton from "@components/form/LinkButton";
 
 export default async function HomePage() {
   const user = await getLoggedInUser();
@@ -45,8 +46,10 @@ export default async function HomePage() {
           marginTop: "1rem",
         }}
       >
-        <LoginButton text="Staff Area" authManager={authManager} />
-        <LoginButton text="User Area" authManager={authManager} />
+        <LinkButton href="/staff" label="Staff Area" />
+        <LinkButton href="/user" label="User Area" />
+        {/* <LoginButton text="Staff Area" authManager={authManager} />
+        <LoginButton text="User Area" authManager={authManager} /> */}
       </div>
     </main>
   );

--- a/app/web/src/auth.ts
+++ b/app/web/src/auth.ts
@@ -30,6 +30,9 @@ const region = process.env.AWS_REGION || "";
 
 export const cognitoConfig: NextAuthOptions = {
   secret: process.env.PRIVACYPAL_AUTH_SECRET ?? "badsecret",
+  pages: {
+    signIn: "/login",
+  },
   providers: [
     CognitoProvider({
       clientId: clientId,

--- a/app/web/src/components/auth/LoginBypass.tsx
+++ b/app/web/src/components/auth/LoginBypass.tsx
@@ -1,0 +1,19 @@
+"use client";
+
+import { signIn } from "next-auth/react";
+import Link from "next/link";
+import { redirect } from "next/navigation";
+import { useEffect } from "react";
+
+interface LoginBypassProps {
+  authManager: string;
+}
+
+export const LoginBypass = ({ authManager }: LoginBypassProps) => {
+  useEffect(() => {
+    // attempt to sign in immediately
+    signIn(authManager);
+  }, []);
+
+  return <p>Redirecting...</p>;
+};


### PR DESCRIPTION
# Welcome to PrivacyPal! 👋

Fixes: #628

## Description of the change:

This alters `/login` to just call `signIn()` on the user's behalf. This may be a better solution because now _anytime_ a user is not authenticated to visit a page, middleware will redirect them to `/login` which will automatically make the actual login form appear.

## Motivation for the change:

Users could be confused if they try to visit an endpoint without being authenticated and this is a general solution to that.

