### PR TITLE
fix(vidproc): fix lambda crashing on edge cases

### DIFF
--- a/app/video-processing/lambda/video_processor.py
+++ b/app/video-processing/lambda/video_processor.py
@@ -169,6 +169,8 @@ class VideoProcessor:
         output.write(self.blur_frame(frame, [start] + regions))
         offset = 1
         for j in range(int(n / frame_gap) + 1):
+            if j * frame_gap == n or j * frame_gap == n - 1:    # protect against edge cases that cause crashes
+                break
             frames = self.get_frames(src, frame_gap, offset)
             boxes = []
             if blur_faces:


### PR DESCRIPTION
# Welcome to PrivacyPal! 👋

Fixes: #654 

## Description of the change:
Handles an edge case where the vidproc loop tries to continue grabbing frames when there aren't any to grab

## Motivation for the change:
necessary for bug-free video processing :skull: 