### PR TITLE
feat(region-select): integrate react-region-select-2

### DIFF
--- a/app/web/package-lock.json
+++ b/app/web/package-lock.json
@@ -24,7 +24,7 @@
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-media-recorder-2": "^1.6.23",
-        "react-region-select": "^2.3.0",
+        "react-region-select-2": "^1.1.0",
         "sharp": "0.32.6",
         "swr": "^2.2.5",
         "zod": "^3.22.4"
@@ -10803,16 +10803,16 @@
         "tslib": "^2.6.2"
       }
     },
-    "node_modules/react-region-select": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/react-region-select/-/react-region-select-2.3.0.tgz",
-      "integrity": "sha512-WcGgt5mgd96glKUyRK2lZ7K885eED1xgQXBieblzOJufNtAu0b/kVw+aINF/HGuhcvln8QND27Lntn3adgI1ow==",
+    "node_modules/react-region-select-2": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/react-region-select-2/-/react-region-select-2-1.1.0.tgz",
+      "integrity": "sha512-ktj6oBiErLbYCqPrwX9g3XGTIshboYnCM35PDiqnyzOiVdZmdcdZ2b9n53n2/6yG2I+NAZRzwUyZrJL3I35Tgw==",
       "dependencies": {
-        "object-assign": "*",
-        "prop-types": "^15.6.0"
+        "object-assign": "^4.1.1",
+        "prop-types": "^15.8.1"
       },
       "peerDependencies": {
-        "react": "^0.14.6 || 15.x || 16.x"
+        "react": "^18.2.0"
       }
     },
     "node_modules/readable-stream": {

--- a/app/web/package.json
+++ b/app/web/package.json
@@ -34,7 +34,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-media-recorder-2": "^1.6.23",
-    "react-region-select": "^2.3.0",
+    "react-region-select-2": "^1.1.0",
     "sharp": "0.32.6",
     "swr": "^2.2.5",
     "zod": "^3.22.4"


### PR DESCRIPTION
# Welcome to PrivacyPal! 👋

Fixes: #680

## Description of the change:

Integrates my custom reimplementation of `react-region-select`. Now supports TypeScript, React 18, and includes interfaces to make interacting with region data more clear. Also adds a `backdrop-filter: blur` CSS style to regions.

![Screenshot 2024-03-10 at 20 27 59](https://github.com/COSC-499-W2023/year-long-project-team-1/assets/3927471/4eff91c0-7750-4e21-9dfe-45b5640d4b55)

## Motivation for the change:

The original library does not support TypeScript and its React depenencies were out of date.

