### PR TITLE
feat(frontend): hide back button when on /

### DIFF
--- a/app/web/src/components/layout/BackButton.tsx
+++ b/app/web/src/components/layout/BackButton.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 "use client";
-import { useRouter } from "next/navigation";
+import { useRouter, usePathname } from "next/navigation";
 import { AngleLeftIcon } from "@patternfly/react-icons";
 import React from "react";
 
@@ -34,6 +34,7 @@ const buttonStyle = {
 
 export default function BackButton({ style }: BackButtonProps) {
   const router = useRouter();
+  const pathname = usePathname();
 
   return (
     <>
@@ -41,6 +42,7 @@ export default function BackButton({ style }: BackButtonProps) {
         type="button"
         onClick={() => router.back()}
         style={{ ...buttonStyle, ...style }}
+        hidden={pathname === "/"}
       >
         <AngleLeftIcon />
         Back


### PR DESCRIPTION
# Welcome to PrivacyPal! 👋

Fixes: #761 

## Description of the change:
Makes the back button on the navbar hide itself when on `/`

## Motivation for the change:
better ux