### PR TITLE
fix(feedback): Template feedback should be able to be sent without logging in 

### DIFF
--- a/app/web/src/middleware.ts
+++ b/app/web/src/middleware.ts
@@ -115,5 +115,5 @@ export default withAuth(
 
 export const config = {
   matcher:
-    "/((?!api/auth|login|logout|signup|_next/static|_next/image|favicon.ico|build.json|health).+)",
+    "/((?!api/auth|login|logout|signup|api/submitFeedback|_next/static|_next/image|favicon.ico|build.json|health).+)",
 };


### PR DESCRIPTION
# Welcome to PrivacyPal! 👋

Fixes: #771 

## Description of the change:
The feedback form in `/` and can only send emails when user is logged in since `middleware.ts` blocked it. I update the middleware config to exclude the API route path  `submitFeedback` .

## Motivation for the change:
Feedback can now be sent without logging in.