### PR TITLE
fix(appt-timeline): videos are shown to be sent by client

### DIFF
--- a/app/web/src/components/appointment/timeline/AppointmentTimeline.tsx
+++ b/app/web/src/components/appointment/timeline/AppointmentTimeline.tsx
@@ -167,6 +167,10 @@ export const AppointmentTimeline = ({
       chatEvent.sender === user.username ? user : contact,
     );
 
+    const clientName = combineNames(
+      user.role === UserRole.CLIENT ? user : contact,
+    );
+
     // if you sent the message, you can delete it
     const deleteHandler = !fromContact
       ? () => {
@@ -192,7 +196,7 @@ export const AppointmentTimeline = ({
       <ConversationVideo
         awsRef={awsRef ?? ""}
         url={eventContent ?? ""}
-        sender={eventSender}
+        sender={clientName}
         time={eventDate}
         style={videoPlayerStyles}
         onDelete={deleteHandler}


### PR DESCRIPTION
# Welcome to PrivacyPal! 👋

Fixes: #780

## Description of the change:

Fixes a problem where the sender of videos was always the other person in the conversation.

## Motivation for the change:

Only `client` users are able to send videos.
