### PR TITLE
feat(frontend): fix zooming in breaking the welcome text

### DIFF
--- a/app/web/src/components/welcome/AboutUs.tsx
+++ b/app/web/src/components/welcome/AboutUs.tsx
@@ -22,11 +22,11 @@ import LoadingButton from "@components/form/LoadingButton";
 const inter = Inter({ subsets: ["latin"] });
 
 const container: CSS = {
-  padding: "10% 0%",
-  position: "relative",
-  marginLeft: "25%",
-  width: "40%",
-  height: "90%",
+  padding: "10vh 0vh",
+  marginLeft: "45%",
+  width: "50vh",
+  height: "90vh",
+  top: "20%",
 };
 const welcomeText: CSS = {
   color: "#0066CC",


### PR DESCRIPTION
# Welcome to PrivacyPal! 👋

Fixes: #812

## Description of the change:
Adds styling to the welcome text so that zooming in to the home page doesn't hide the text under the navbar.

## Motivation for the change:
improved UX for people who may have a larger default page zoom.
