### PR TITLE
docs(helm): fix readme typo in helm docs

### DIFF
--- a/helm-charts/charts/privacypal/Chart.yaml
+++ b/helm-charts/charts/privacypal/Chart.yaml
@@ -17,7 +17,7 @@ keywords:
   - video-processing
   - security
 
-home: https://github.com/COSC-499-W2023/year-long-project-team-1/wiki
+home: https://github.com/COSC-499-W2023/year-long-project-team-1
 
 # icon:
 

--- a/helm-charts/charts/privacypal/README.md
+++ b/helm-charts/charts/privacypal/README.md
@@ -2,6 +2,8 @@
 
 Helm Chart to deploy [Privacypal](https://github.com/COSC-499-W2023/year-long-project-team-1/wiki) application on Kubernetes. Currently, only AWS EKS is supported.
 
+Follow the [`SETUP.md`](./SETUP.md) for more details on AWS EKS requirements.
+
 ## Parameters
 
 ### PrivacyPal Application
@@ -64,7 +66,7 @@ Helm Chart to deploy [Privacypal](https://github.com/COSC-499-W2023/year-long-pr
 | `database.initializer.image.tag`        | Tag for the database initializer container image                                                                                                                              | `0.1.0-dev`    |
 | `database.initializer.image.pullPolicy` | Image pull policy for the database initializer container image                                                                                                                | `Always`       |
 
-### Authentcation
+### Authentication
 
 | Name                             | Description                                                                                                                                      | Value  |
 | -------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ | ------ |

--- a/helm-charts/charts/privacypal/values.yaml
+++ b/helm-charts/charts/privacypal/values.yaml
@@ -116,7 +116,7 @@ database:
       ## @param database.initializer.image.pullPolicy Image pull policy for the database initializer container image
       pullPolicy: Always
 
-## @section Authentcation
+## @section Authentication
 ## @extra auth Authentication configurations.
 auth:
   ## @extra auth.cognito Configurations for AWS Cognito Authentication


### PR DESCRIPTION
# Welcome to PrivacyPal! 👋

Related to #759 

## Description of the change:

Fix typo in helm README.
Updated Chart's home page to repo url (i.e. wiki is now disabled).

## Motivation for the change:

See #759 
