### PR TITLE
fix(helm): fix lambda output bucket env var missing namespace

### DIFF
--- a/helm-charts/charts/privacypal/templates/lambda.yaml
+++ b/helm-charts/charts/privacypal/templates/lambda.yaml
@@ -11,14 +11,14 @@ metadata:
 spec:
   name: {{ .Release.Namespace }}-{{ $fullName }}-vidproc
   packageType: Image
+  environment: 
+    variables:
+      OUTPUT_BUCKET: {{ .Release.Namespace }}-{{ $fullName }}-videos
   {{- with .Values.lambda.videoProcessor }}
   code:
     imageURI: "{{ .image.repository }}:{{ .image.tag }}"
   role: {{ .iamRole }}
   description: Video processing Lambda to process videos submitted by users
-  environment: 
-    variables:
-      OUTPUT_BUCKET: {{ $fullName }}-videos
   ephemeralStorage: 
     size: {{ .ephemeralStorageSize }}
   memorySize: {{ .memorySize }}


### PR DESCRIPTION
# Welcome to PrivacyPal! 👋

Related to #394 

## Description of the change:

Added namespace to the output env var that specifies the bucket name.

## Motivation for the change:

Broken S3 Upload operations.